### PR TITLE
fix: Do not return error if file is skipped due to only text detection

### DIFF
--- a/pkg/bidirectional/bidirectionnal.go
+++ b/pkg/bidirectional/bidirectionnal.go
@@ -148,7 +148,7 @@ func scanFile(filename string, cfg *config.Config) int {
 				}
 				utils.ErrorLogger.Println("check", filename, "...", result)
 			}
-			return 1
+			return 0
 		}
 	}
 

--- a/pkg/homoglyph/homoglyph.go
+++ b/pkg/homoglyph/homoglyph.go
@@ -94,7 +94,7 @@ func scanFile(filename string, cfg *config.Config) int {
 				}
 				utils.ErrorLogger.Println("check", filename, "...", result)
 			}
-			return 1
+			return 0
 		}
 	}
 


### PR DESCRIPTION
We had problems in our ci-pipeline with the result code when only text files are scanned.
Looks like the return code if skipped files was wrong.